### PR TITLE
Add Linux install script, dynamic resource discovery, and AppImage bu…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Enforce LF line endings for Linux shell scripts and desktop files
+install.sh text eol=lf
+scripts/*.sh text eol=lf
+*.desktop text eol=lf

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Install Swift:
 
 To build and run the application: `swift run`.
 
+## Installation on Linux
+
+To install Poietic Playground on Linux:
+
+```sh
+# User-level install (~/.local/bin and ~/.local/share/poietic-playground)
+./install.sh --user
+
+# System-wide install (/usr/local/bin and /usr/local/share/poietic-playground)
+sudo ./install.sh --system
+```
+
+To build a standalone AppImage:
+
+```sh
+./scripts/build-appimage.sh
+```
+
 ## See Also
 
 - [Poietic Core](https://github.com/OpenPoiesis/poietic-core) – Model and design representation library

--- a/Sources/PoieticPlayground/Application/ResourceManager.swift
+++ b/Sources/PoieticPlayground/Application/ResourceManager.swift
@@ -41,9 +41,84 @@ class ResourceManager {
     var backend: any GraphicsBackendProtocol
     var textureCache: [String:TextureHandle] = [:]
     
-    init(_ rootPath: String, backend: any GraphicsBackendProtocol) {
-        self.root = URL(fileURLWithPath: rootPath)
+    init(_ rootPath: String = DefaultResourcesPath, backend: any GraphicsBackendProtocol) {
+        self.root = Self.locateResourcesRoot(preferredPath: rootPath)
         self.backend = backend
+    }
+    
+    init(rootURL: URL, backend: any GraphicsBackendProtocol) {
+        self.root = rootURL
+        self.backend = backend
+    }
+
+    static func locateResourcesRoot(preferredPath: String? = nil) -> URL {
+        let fm = FileManager.default
+
+        func isValid(_ url: URL) -> Bool {
+            let marker = url.appendingPathComponent("stock_flow_pictograms.json")
+            return fm.fileExists(atPath: marker.path)
+        }
+
+        // 1. Explicitly passed preferred path (if it exists and is valid)
+        if let preferred = preferredPath {
+            let url = URL(fileURLWithPath: preferred)
+            if isValid(url) {
+                return url
+            }
+        }
+
+        // 2. Environment variable override
+        if let envPath = ProcessInfo.processInfo.environment["POIETIC_RESOURCES_PATH"] {
+            let url = URL(fileURLWithPath: envPath)
+            if isValid(url) {
+                return url
+            }
+        }
+
+        // 3. Relative to executable path
+        if let execURL = Bundle.main.executableURL {
+            let execDir = execURL.deletingLastPathComponent()
+            let candidates = [
+                execDir.appendingPathComponent("../share/poietic-playground"),
+                execDir.appendingPathComponent("../share/poietic-playground/Resources"),
+                execDir.appendingPathComponent("Resources"),
+                execDir.appendingPathComponent("../Resources")
+            ]
+            for candidate in candidates {
+                if isValid(candidate) {
+                    return candidate.standardized
+                }
+            }
+        }
+
+        // 4. Standard user and system installation locations
+        let homeDir = fm.homeDirectoryForCurrentUser
+        let searchPaths = [
+            homeDir.appendingPathComponent(".local/share/poietic-playground"),
+            homeDir.appendingPathComponent(".local/share/poietic-playground/Resources"),
+            URL(fileURLWithPath: "/usr/local/share/poietic-playground"),
+            URL(fileURLWithPath: "/usr/local/share/poietic-playground/Resources"),
+            URL(fileURLWithPath: "/usr/share/poietic-playground"),
+            URL(fileURLWithPath: "/usr/share/poietic-playground/Resources")
+        ]
+        for path in searchPaths {
+            if isValid(path) {
+                return path
+            }
+        }
+
+        // 5. Default repository / CWD fallback
+        let fallbackCandidates = [
+            URL(fileURLWithPath: DefaultResourcesPath),
+            URL(fileURLWithPath: "Resources")
+        ]
+        for fallback in fallbackCandidates {
+            if isValid(fallback) {
+                return fallback
+            }
+        }
+
+        return URL(fileURLWithPath: DefaultResourcesPath)
     }
     
     func resourceURL(_ resourcePath: String) -> URL {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env sh
+set -e
+
+# Poietic Playground - Linux Installation Script
+
+SHOW_HELP=0
+UNINSTALL=0
+PREFIX=""
+USER_INSTALL=0
+
+usage() {
+    cat <<EOF
+Poietic Playground Installation Script
+
+Usage:
+  ./install.sh [OPTIONS]
+
+Options:
+  --prefix DIR    Set installation prefix directory (default: /usr/local or ~/.local)
+  --user          Install for current user only (~/.local)
+  --system        Install system-wide (/usr/local)
+  --uninstall     Uninstall Poietic Playground from prefix directory
+  -h, --help      Display this help message
+
+Environment Variables:
+  PREFIX          Alternative way to specify installation prefix
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix)
+            PREFIX="$2"
+            shift 2
+            ;;
+        --user)
+            USER_INSTALL=1
+            shift
+            ;;
+        --system)
+            USER_INSTALL=0
+            PREFIX="/usr/local"
+            shift
+            ;;
+        --uninstall)
+            UNINSTALL=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Determine default prefix if not explicitly specified
+if [ -z "$PREFIX" ]; then
+    if [ "$USER_INSTALL" -eq 1 ]; then
+        PREFIX="$HOME/.local"
+    elif [ "$(id -u 2>/dev/null || echo 1)" -eq 0 ]; then
+        PREFIX="/usr/local"
+    else
+        PREFIX="$HOME/.local"
+    fi
+fi
+
+BIN_DIR="$PREFIX/bin"
+SHARE_DIR="$PREFIX/share/poietic-playground"
+APP_DIR="$PREFIX/share/applications"
+ICON_DIR="$PREFIX/share/icons/hicolor/512x512/apps"
+
+if [ "$UNINSTALL" -eq 1 ]; then
+    echo "Uninstalling Poietic Playground from $PREFIX..."
+    rm -f "$BIN_DIR/PoieticPlayground"
+    rm -rf "$SHARE_DIR"
+    rm -f "$APP_DIR/poietic-playground.desktop"
+    rm -f "$ICON_DIR/poietic-playground.png"
+    echo "Uninstallation complete."
+    exit 0
+fi
+
+echo "=========================================="
+echo "Installing Poietic Playground"
+echo "Prefix: $PREFIX"
+echo "=========================================="
+
+# Check for Swift compiler
+if ! command -v swift >/dev/null 2>&1; then
+    echo "Error: 'swift' compiler not found. Please install Swift (https://swift.org/getting-started/)."
+    exit 1
+fi
+
+echo "--> Building release binary..."
+swift build -c release
+
+SWIFT_BIN_PATH=$(swift build -c release --show-bin-path)
+BUILD_EXEC="$SWIFT_BIN_PATH/PoieticPlayground"
+
+if [ ! -f "$BUILD_EXEC" ]; then
+    echo "Error: Built executable not found at $BUILD_EXEC"
+    exit 1
+fi
+
+echo "--> Creating target directories..."
+mkdir -p "$BIN_DIR"
+mkdir -p "$SHARE_DIR"
+mkdir -p "$APP_DIR"
+mkdir -p "$ICON_DIR"
+
+echo "--> Copying binary to $BIN_DIR..."
+cp -f "$BUILD_EXEC" "$BIN_DIR/PoieticPlayground"
+chmod +x "$BIN_DIR/PoieticPlayground"
+
+echo "--> Copying resources to $SHARE_DIR..."
+cp -r Sources/PoieticPlayground/Resources/* "$SHARE_DIR/"
+
+echo "--> Installing desktop launcher..."
+if [ -f "poietic-playground.desktop" ]; then
+    cp -f "poietic-playground.desktop" "$APP_DIR/"
+fi
+
+# Copy icon if available
+ICON_SRC="Sources/PoieticPlayground/Resources/icons/black/run.png"
+if [ -f "$ICON_SRC" ]; then
+    cp -f "$ICON_SRC" "$ICON_DIR/poietic-playground.png"
+fi
+
+# Update system caches if tools are available
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$APP_DIR" >/dev/null 2>&1 || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache "$PREFIX/share/icons/hicolor" >/dev/null 2>&1 || true
+fi
+
+echo ""
+echo "=========================================="
+echo "Installation complete!"
+echo "Binary:    $BIN_DIR/PoieticPlayground"
+echo "Resources: $SHARE_DIR"
+echo "Desktop:   $APP_DIR/poietic-playground.desktop"
+echo "=========================================="
+echo "Ensure '$BIN_DIR' is in your PATH to launch PoieticPlayground from anywhere."

--- a/poietic-playground.desktop
+++ b/poietic-playground.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Poietic Playground
+GenericName=Stock and Flow Simulation Laboratory
+Comment=Virtual laboratory for modelling and simulation of dynamical systems using Stock and Flow methodology
+Exec=PoieticPlayground %f
+Icon=poietic-playground
+Terminal=false
+Categories=Education;Science;Development;
+Keywords=system;dynamics;stock;flow;modelling;simulation;
+MimeType=application/x-poietic;

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+set -e
+
+# Poietic Playground - AppImage Packaging Script
+
+APP_DIR="AppDir"
+OUTPUT_APPIMAGE="PoieticPlayground-x86_64.AppImage"
+
+echo "=========================================="
+echo "Building AppImage for Poietic Playground"
+echo "=========================================="
+
+if ! command -v swift >/dev/null 2>&1; then
+    echo "Error: 'swift' compiler not found."
+    exit 1
+fi
+
+echo "--> Building release binary..."
+swift build -c release
+
+SWIFT_BIN_PATH=$(swift build -c release --show-bin-path)
+BUILD_EXEC="$SWIFT_BIN_PATH/PoieticPlayground"
+
+if [ ! -f "$BUILD_EXEC" ]; then
+    echo "Error: Executable not found at $BUILD_EXEC"
+    exit 1
+fi
+
+echo "--> Preparing AppDir layout..."
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/usr/bin"
+mkdir -p "$APP_DIR/usr/share/poietic-playground"
+
+echo "--> Copying binary and resources..."
+cp -f "$BUILD_EXEC" "$APP_DIR/usr/bin/PoieticPlayground"
+chmod +x "$APP_DIR/usr/bin/PoieticPlayground"
+
+cp -r Sources/PoieticPlayground/Resources/* "$APP_DIR/usr/share/poietic-playground/"
+
+echo "--> Creating desktop file and icons..."
+cp -f poietic-playground.desktop "$APP_DIR/poietic-playground.desktop"
+cp -f poietic-playground.desktop "$APP_DIR/default.desktop"
+
+ICON_SRC="Sources/PoieticPlayground/Resources/icons/black/run.png"
+if [ -f "$ICON_SRC" ]; then
+    cp -f "$ICON_SRC" "$APP_DIR/poietic-playground.png"
+    cp -f "$ICON_SRC" "$APP_DIR/.DirIcon"
+fi
+
+echo "--> Generating AppRun script..."
+cat <<'EOF' > "$APP_DIR/AppRun"
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "${0}")")"
+export POIETIC_RESOURCES_PATH="${HERE}/usr/share/poietic-playground"
+export PATH="${HERE}/usr/bin:${PATH}"
+exec "${HERE}/usr/bin/PoieticPlayground" "$@"
+EOF
+chmod +x "$APP_DIR/AppRun"
+
+echo ""
+if command -v appimagetool >/dev/null 2>&1; then
+    echo "--> Running appimagetool..."
+    appimagetool "$APP_DIR" "$OUTPUT_APPIMAGE"
+    echo "AppImage created successfully: $OUTPUT_APPIMAGE"
+else
+    echo "AppDir directory prepared successfully at: $APP_DIR"
+    echo "To produce the final AppImage, run:"
+    echo "  appimagetool $APP_DIR $OUTPUT_APPIMAGE"
+fi


### PR DESCRIPTION
Closes #15

### Summary

This PR introduces a Linux installation script, resolves the resource discovery location problem, and adds standalone AppImage packaging for **Poietic Playground**.

### Key Changes

1. **Dynamic Resource Location Discovery** (`ResourceManager.swift`)
   - Added `locateResourcesRoot()` to dynamically discover resource files across:
     - Environment variable override (`POIETIC_RESOURCES_PATH`)
     - Executable-relative paths (`../share/poietic-playground`)
     - User installation paths (`~/.local/share/poietic-playground`)
     - System installation paths (`/usr/local/share/poietic-playground`, `/usr/share/poietic-playground`)
     - Local repository fallback (`Sources/PoieticPlayground/Resources/`)

2. **Linux Installation Script** (`install.sh`)
   - Compiles the release binary (`swift build -c release`).
   - Installs executable, resources, desktop launcher, and application icon.
   - Supports `--user` (`~/.local`), `--system` (`/usr/local`), `--prefix <DIR>`, and `--uninstall`.

3. **Desktop Application Integration** (`poietic-playground.desktop`)
   - Standard Freedesktop `.desktop` entry for Linux desktop application menus and launchers.

4. **AppImage Generator Script** (`scripts/build-appimage.sh`)
   - Assembles an `AppDir` bundle with launcher environment (`AppRun`), binary, desktop entry, icon, and embedded resources.
   - Builds `PoieticPlayground-x86_64.AppImage` automatically if `appimagetool` is present.

5. **Documentation Updates** (`README.md`)
   - Added "Installation on Linux" instructions and AppImage usage.