### PR TITLE
Add macOS app bundle build script, Info.plist, and resource location …

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>PoieticPlayground</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.poietic.PoieticPlayground</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Poietic Playground</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Install Swift:
 
 To build and run the application: `swift run`.
 
+## Building macOS App Bundle
+
+To build a standalone macOS `.app` bundle containing all resources:
+
+```sh
+./scripts/build-macos-app.sh
+```
+
+The generated application bundle will be located at `.build/macos/Poietic Playground.app`.
+
 ## See Also
 
 - [Poietic Core](https://github.com/OpenPoiesis/poietic-core) – Model and design representation library

--- a/Sources/PoieticPlayground/Application/ResourceManager.swift
+++ b/Sources/PoieticPlayground/Application/ResourceManager.swift
@@ -41,9 +41,89 @@ class ResourceManager {
     var backend: any GraphicsBackendProtocol
     var textureCache: [String:TextureHandle] = [:]
     
-    init(_ rootPath: String, backend: any GraphicsBackendProtocol) {
-        self.root = URL(fileURLWithPath: rootPath)
+    init(_ rootPath: String = DefaultResourcesPath, backend: any GraphicsBackendProtocol) {
+        self.root = Self.locateResourcesRoot(preferredPath: rootPath)
         self.backend = backend
+    }
+
+    init(rootURL: URL, backend: any GraphicsBackendProtocol) {
+        self.root = rootURL
+        self.backend = backend
+    }
+
+    static func locateResourcesRoot(preferredPath: String? = nil) -> URL {
+        let fm = FileManager.default
+
+        func isValid(_ url: URL) -> Bool {
+            let marker = url.appendingPathComponent("stock_flow_pictograms.json")
+            return fm.fileExists(atPath: marker.path)
+        }
+
+        // 1. Explicitly passed preferred path (if it exists and is valid)
+        if let preferred = preferredPath {
+            let url = URL(fileURLWithPath: preferred)
+            if isValid(url) {
+                return url
+            }
+        }
+
+        // 2. Environment variable override
+        if let envPath = ProcessInfo.processInfo.environment["POIETIC_RESOURCES_PATH"] {
+            let url = URL(fileURLWithPath: envPath)
+            if isValid(url) {
+                return url
+            }
+        }
+
+        // 3. macOS App Bundle main resource URL
+        if let mainResourceURL = Bundle.main.resourceURL, isValid(mainResourceURL) {
+            return mainResourceURL.standardized
+        }
+
+        // 4. Relative to executable path (e.g. Contents/MacOS/../Resources inside macOS .app bundle)
+        if let execURL = Bundle.main.executableURL {
+            let execDir = execURL.deletingLastPathComponent()
+            let candidates = [
+                execDir.appendingPathComponent("../Resources"),
+                execDir.appendingPathComponent("../share/poietic-playground"),
+                execDir.appendingPathComponent("../share/poietic-playground/Resources"),
+                execDir.appendingPathComponent("Resources")
+            ]
+            for candidate in candidates {
+                if isValid(candidate) {
+                    return candidate.standardized
+                }
+            }
+        }
+
+        // 5. Standard user and system installation locations
+        let homeDir = fm.homeDirectoryForCurrentUser
+        let searchPaths = [
+            homeDir.appendingPathComponent(".local/share/poietic-playground"),
+            homeDir.appendingPathComponent(".local/share/poietic-playground/Resources"),
+            URL(fileURLWithPath: "/usr/local/share/poietic-playground"),
+            URL(fileURLWithPath: "/usr/local/share/poietic-playground/Resources"),
+            URL(fileURLWithPath: "/usr/share/poietic-playground"),
+            URL(fileURLWithPath: "/usr/share/poietic-playground/Resources")
+        ]
+        for path in searchPaths {
+            if isValid(path) {
+                return path
+            }
+        }
+
+        // 6. Default repository / CWD fallback
+        let fallbackCandidates = [
+            URL(fileURLWithPath: DefaultResourcesPath),
+            URL(fileURLWithPath: "Resources")
+        ]
+        for fallback in fallbackCandidates {
+            if isValid(fallback) {
+                return fallback
+            }
+        }
+
+        return URL(fileURLWithPath: DefaultResourcesPath)
     }
     
     func resourceURL(_ resourcePath: String) -> URL {

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+set -e
+
+# Poietic Playground - macOS App Bundle Builder Script
+
+BUILD_CONFIG="release"
+OUTPUT_DIR=".build/macos"
+APP_NAME="Poietic Playground.app"
+
+usage() {
+    cat <<EOF
+Poietic Playground macOS App Bundle Builder
+
+Usage:
+  ./scripts/build-macos-app.sh [OPTIONS]
+
+Options:
+  --debug         Build in debug mode instead of release mode
+  --output DIR    Specify output directory for .app bundle (default: .build/macos)
+  -h, --help      Display this help message
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --debug)
+            BUILD_CONFIG="debug"
+            shift
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+echo "=========================================="
+echo "Building macOS App Bundle ($BUILD_CONFIG)"
+echo "=========================================="
+
+if ! command -v swift >/dev/null 2>&1; then
+    echo "Error: 'swift' compiler not found."
+    exit 1
+fi
+
+echo "--> Compiling executable..."
+swift build -c "$BUILD_CONFIG"
+
+SWIFT_BIN_PATH=$(swift build -c "$BUILD_CONFIG" --show-bin-path)
+BUILD_EXEC="$SWIFT_BIN_PATH/PoieticPlayground"
+
+if [ ! -f "$BUILD_EXEC" ]; then
+    echo "Error: Executable not found at $BUILD_EXEC"
+    exit 1
+fi
+
+TARGET_APP_PATH="$OUTPUT_DIR/$APP_NAME"
+CONTENTS_DIR="$TARGET_APP_PATH/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+
+echo "--> Preparing bundle directory at $TARGET_APP_PATH..."
+rm -rf "$TARGET_APP_PATH"
+mkdir -p "$MACOS_DIR"
+mkdir -p "$RESOURCES_DIR"
+
+echo "--> Copying executable..."
+cp -f "$BUILD_EXEC" "$MACOS_DIR/PoieticPlayground"
+chmod +x "$MACOS_DIR/PoieticPlayground"
+
+echo "--> Copying resources..."
+cp -r Sources/PoieticPlayground/Resources/* "$RESOURCES_DIR/"
+
+echo "--> Copying Info.plist..."
+if [ -f "Info.plist" ]; then
+    cp -f Info.plist "$CONTENTS_DIR/Info.plist"
+else
+    echo "Warning: Info.plist not found, skipping."
+fi
+
+# Code sign if codesign tool is present (macOS ad-hoc signing)
+if command -v codesign >/dev/null 2>&1; then
+    echo "--> Ad-hoc signing app bundle..."
+    codesign -s - --force --deep "$TARGET_APP_PATH" >/dev/null 2>&1 || true
+fi
+
+echo ""
+echo "=========================================="
+echo "macOS Application Bundle created successfully!"
+echo "Bundle location: $TARGET_APP_PATH"
+echo "=========================================="


### PR DESCRIPTION
Closes #14

### Summary

This PR adds a macOS `.app` bundle build script, property list metadata (`Info.plist`), and resource path discovery for macOS application distribution.

### Key Changes

1. **macOS `.app` Bundle Resource Support** (`ResourceManager.swift`)
   - Updated `locateResourcesRoot()` to search `Bundle.main.resourceURL` (which points to `Contents/Resources` in macOS app bundles) and `../Resources` relative to the binary path (`Contents/MacOS/`).

2. **Application Metadata** (`Info.plist`)
   - Standard macOS application property list file defining bundle identifier (`org.poietic.PoieticPlayground`), executable name (`PoieticPlayground`), display name (`Poietic Playground`), minimum system version, and High-DPI support.

3. **macOS App Bundle Builder Script** (`scripts/build-macos-app.sh`)
   - Compiles executable using `swift build -c release`.
   - Assembles standard macOS application bundle layout:
     ```
     Poietic Playground.app/
     └── Contents/
         ├── Info.plist
         ├── MacOS/
         │   └── PoieticPlayground
         └── Resources/
             ├── icons/
             ├── designs/
             └── stock_flow_pictograms.json
     ```
   - Automatically ad-hoc signs bundle with `codesign` when available.

4. **Documentation Updates** (`README.md`)
   - Added instructions for building macOS app bundle (`./scripts/build-macos-app.sh`).