### PR TITLE
Add canvas style selection and loading from JSON in SettingsPanel (#12)

### DIFF
--- a/Sources/PoieticPlayground/Application/Application+Resources.swift
+++ b/Sources/PoieticPlayground/Application/Application+Resources.swift
@@ -55,6 +55,36 @@ extension Application {
         )
         self.log("Notation loaded. \(notation.pictograms.count) pictograms, \(notation.connectorGlyphs.count) connector glyphs.")
         self.notation = notation
-        // TODO: Update the world
+        if let document {
+            document.world.setSingleton(notation)
+            document.needsWorldFrameUpdate = true
+        }
+    }
+
+    func selectCanvasStyle(_ style: CanvasStyleDescriptor) {
+        if let resourcePath = style.resourcePath {
+            let url = ResourceManager.shared.resourceURL(resourcePath)
+            self.loadNotation(url: url)
+            self.currentCanvasStyleID = style.id
+        }
+    }
+
+    func selectCanvasStyle(id: String) {
+        guard let style = canvasStyles.first(where: { $0.id == id }) else { return }
+        selectCanvasStyle(style)
+    }
+
+    func loadCanvasStyleFromJSON(url: URL) {
+        self.loadNotation(url: url)
+        let styleName = url.deletingPathExtension().lastPathComponent
+        let customStyleID = "custom_\(url.path)"
+        let customStyle = CanvasStyleDescriptor(id: customStyleID, name: "Custom (\(styleName))", resourcePath: nil)
+        
+        if let index = canvasStyles.firstIndex(where: { $0.id == customStyleID }) {
+            canvasStyles[index] = customStyle
+        } else {
+            canvasStyles.append(customStyle)
+        }
+        self.currentCanvasStyleID = customStyleID
     }
 }

--- a/Sources/PoieticPlayground/Application/Application.swift
+++ b/Sources/PoieticPlayground/Application/Application.swift
@@ -12,6 +12,12 @@ import Csdl3
 import Diagramming
 import Foundation
 
+struct CanvasStyleDescriptor: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let resourcePath: String?
+}
+
 /// Main orchestrator
 ///
 /// Responsibilities:
@@ -30,6 +36,16 @@ class Application {
     }
     internal static var _shared: Application? = nil
     
+    static let BuiltinCanvasStyles: [CanvasStyleDescriptor] = [
+        CanvasStyleDescriptor(id: "default", name: "Standard Stock & Flow", resourcePath: "stock_flow_pictograms.json"),
+        CanvasStyleDescriptor(id: "jolly", name: "Jolly Stock & Flow", resourcePath: "stock_flow_pictograms-jolly.json"),
+        CanvasStyleDescriptor(id: "old", name: "Classic Stock & Flow", resourcePath: "stock_flow_pictograms-old.json"),
+        CanvasStyleDescriptor(id: "jolly-old", name: "Classic Jolly Stock & Flow", resourcePath: "stock_flow_pictograms-jolly-old.json"),
+    ]
+
+    var canvasStyles: [CanvasStyleDescriptor] = Self.BuiltinCanvasStyles
+    var currentCanvasStyleID: String = "default"
+
     // Dumping ground of globals (for now)
     //    static let NewDesignTemplatePath = "designs/new_canvas.json"
     static let NewDesignTemplatePath = "designs/design-capital.poietic"

--- a/Sources/PoieticPlayground/Application/Settings.swift
+++ b/Sources/PoieticPlayground/Application/Settings.swift
@@ -20,7 +20,8 @@ class SettingsPanel: Panel {
         guard isVisible else { return }
         ImGui.Begin("Settings", &isVisible, ImGuiWindowFlags_None | ImGuiWindowFlags_NoCollapse)
         drawInterfaceStyleSettings()
-//        drawNotationSettings()
+        ImGui.Spacing()
+        drawNotationSettings()
         ImGui.End()
     }
    
@@ -38,7 +39,23 @@ class SettingsPanel: Panel {
     }
     
     func drawNotationSettings() {
-        ImGui.SeparatorText("Notation")
+        guard let app else { return }
+        ImGui.SeparatorText("Canvas Style")
+
+        for style in app.canvasStyles {
+            let isSelected = (app.currentCanvasStyleID == style.id)
+            if ImGui.RadioButton(style.name, isSelected) {
+                app.selectCanvasStyle(style)
+            }
+        }
+
+        ImGui.Spacing()
+        if ImGui.Button("Load Style from JSON...") {
+            app.filePicker.open(mode: .open, filter: "*.json") { path in
+                let url = URL(fileURLWithPath: path)
+                app.loadCanvasStyleFromJSON(url: url)
+            }
+        }
     }
     
     func setInterfaceColorScheme(_ scheme: InterfaceStyle.ColorScheme) {


### PR DESCRIPTION
Closes #12

### Summary

This PR adds human-readable canvas style selection and custom JSON style loading in the Preferences / Settings panel.

### Key Changes

1. **Canvas Style Representation & Built-in Styles** (`Application.swift`)
   - Introduced `CanvasStyleDescriptor` (`id`, `name`, `resourcePath`).
   - Defined `BuiltinCanvasStyles` array containing:
     - Standard Stock & Flow (`stock_flow_pictograms.json`)
     - Jolly Stock & Flow (`stock_flow_pictograms-jolly.json`)
     - Classic Stock & Flow (`stock_flow_pictograms-old.json`)
     - Classic Jolly Stock & Flow (`stock_flow_pictograms-jolly-old.json`)
   - Added `canvasStyles` list and `currentCanvasStyleID` state properties.

2. **Dynamic Notation Switching & Custom JSON Loading** (`Application+Resources.swift`)
   - Implemented `selectCanvasStyle(_:)` to switch between built-in and custom loaded styles.
   - Implemented `loadCanvasStyleFromJSON(url:)` to load any external pictogram JSON file via file picker.
   - Updated `loadNotation(url:)` to update `document.world.setSingleton(notation)` and trigger `document.needsWorldFrameUpdate = true` so open documents refresh graphics immediately.

3. **SettingsPanel Preferences UI** (`Settings.swift`)
   - Implemented `drawNotationSettings()` in `SettingsPanel`.
   - Added radio button style picker.
   - Added **Load Style from JSON...** button linking to `filePicker.open(mode: .open, filter: "*.json")`.